### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-fluent-plugin-munin [![Build Status](https://travis-ci.org/y-ken/fluent-plugin-munin.png?branch=master)](https://travis-ci.org/y-ken/fluent-plugin-munin)
+fluent-plugin-munin, a plugin for [Fluentd](http://fluentd.org) [![Build Status](https://travis-ci.org/y-ken/fluent-plugin-munin.png?branch=master)](https://travis-ci.org/y-ken/fluent-plugin-munin)
 ===================
 
 ## Component


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
